### PR TITLE
Refactor outputstructuur van `process_from_list` in MonumentenClient naar dictionary-indeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,32 +38,29 @@ await main()
 
 ```python
 # OUTPUT
-[
-    {
-        'bag_verblijfsobject_id': '0599010000360091',
-        'is_rijksmonument': True,
-        'rijksmonument_nummer': '524327',
-        'rijksmonument_url': 'https://monumenten.nl/monument/524327',
-        'is_beschermd_gezicht': False,
-        'beschermd_gezicht_naam': None
-    },
-    {
-        'bag_verblijfsobject_id': '0599010000486642',
-        'is_rijksmonument': False,
-        'rijksmonument_nummer': None,
-        'rijksmonument_url': None,
-        'is_beschermd_gezicht': False,
-        'beschermd_gezicht_naam': None
-    },
-    {
-        'bag_verblijfsobject_id': '0599010000281115',
-        'is_rijksmonument': False,
-        'rijksmonument_nummer': None,
-        'rijksmonument_url': None,
-        'is_beschermd_gezicht': True,
-        'beschermd_gezicht_naam': 'Kralingen - Midden'
-    }
-]
+{
+  '0599010000360091': {
+    'is_rijksmonument': True,
+    'rijksmonument_nummer': '524327',
+    'rijksmonument_url': 'https://monumenten.nl/monument/524327',
+    'is_beschermd_gezicht': False,
+    'beschermd_gezicht_naam': None
+  },
+  '0599010000486642': {
+    'is_rijksmonument': False,
+    'rijksmonument_nummer': None,
+    'rijksmonument_url': None,
+    'is_beschermd_gezicht': False,
+    'beschermd_gezicht_naam': None
+  },
+  '0599010000281115': {
+    'is_rijksmonument': False,
+    'rijksmonument_nummer': None,
+    'rijksmonument_url': None,
+    'is_beschermd_gezicht': True,
+    'beschermd_gezicht_naam': 'Kralingen - Midden'
+  }
+}
 ```
 
 ### Met pandas 🐼

--- a/src/monumenten/client.py
+++ b/src/monumenten/client.py
@@ -1,6 +1,6 @@
 """Client voor monumenten package."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import aiohttp
 import pandas as pd
@@ -95,16 +95,19 @@ class MonumentenClient:
 
     async def process_from_list(
         self, verblijfsobject_ids: List[str]
-    ) -> List[Dict[str, Any]]:
+    ) -> Dict[str, Dict[str, Any]]:
         """Verwerk een lijst met verblijfsobject ID's.
 
         Args:
             verblijfsobject_ids (List[str]): Lijst met te verwerken ID's
 
         Returns:
-            List[Dict[str, Any]]: Lijst met dictionaries met monumentinformatie
+            Dict[str, Dict[str, Any]]: Dictionary met verblijfsobject ID's als keys en dictionaries met monumentinformatie als values
         """
         df = pd.DataFrame({"bag_verblijfsobject_id": verblijfsobject_ids})
         result = await self.process_from_df(df, "bag_verblijfsobject_id")
         result = result.replace({pd.NA: None, pd.NaT: None})
-        return list(result.to_dict(orient="records"))
+        return cast(
+            Dict[str, Dict[str, Any]],
+            result.set_index("bag_verblijfsobject_id").to_dict(orient="index"),
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,23 +23,26 @@ async def test_process_from_list(client):
     assert len(result) == 3
 
     # Test rijksmonument
-    assert result[0]["bag_verblijfsobject_id"] == "0599010000360091"
-    assert result[0]["is_rijksmonument"] is True
-    assert result[0]["rijksmonument_nummer"] == "524327"
-    assert result[0]["rijksmonument_url"] == "https://monumenten.nl/monument/524327"
-    assert result[0]["is_beschermd_gezicht"] is False
+    assert "0599010000360091" in result
+    assert result["0599010000360091"]["is_rijksmonument"] is True
+    assert result["0599010000360091"]["rijksmonument_nummer"] == "524327"
+    assert (
+        result["0599010000360091"]["rijksmonument_url"]
+        == "https://monumenten.nl/monument/524327"
+    )
+    assert result["0599010000360091"]["is_beschermd_gezicht"] is False
 
     # Test non-monument
-    assert result[1]["bag_verblijfsobject_id"] == "0599010000486642"
-    assert result[1]["is_rijksmonument"] is False
-    assert pd.isna(result[1]["rijksmonument_nummer"])
-    assert result[1]["is_beschermd_gezicht"] is False
+    assert "0599010000486642" in result
+    assert result["0599010000486642"]["is_rijksmonument"] is False
+    assert result["0599010000486642"]["rijksmonument_nummer"] is None
+    assert result["0599010000486642"]["is_beschermd_gezicht"] is False
 
     # Test beschermd gezicht
-    assert result[2]["bag_verblijfsobject_id"] == "0599010000281115"
-    assert result[2]["is_rijksmonument"] is False
-    assert result[2]["is_beschermd_gezicht"] is True
-    assert result[2]["beschermd_gezicht_naam"] == "Kralingen - Midden"
+    assert "0599010000281115" in result
+    assert result["0599010000281115"]["is_rijksmonument"] is False
+    assert result["0599010000281115"]["is_beschermd_gezicht"] is True
+    assert result["0599010000281115"]["beschermd_gezicht_naam"] == "Kralingen - Midden"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Deze wijziging transformeert de output van de methode `process_from_list` in de `MonumentenClient` van een lijst met dictionaries naar een geneste dictionarystructuur. In plaats van een lijst van resultaten, worden de verblijfsobject-ID’s nu gebruikt als sleutels, wat directe toegang tot de objectdata mogelijk maakt. 

Belangrijkste wijzigingen:
- Aanpassing van `process_from_list` om een dictionary terug te geven met verblijfsobject-ID's als sleutels en hun corresponderende monumentinformatie als values.
- Refactor van `test_process_from_list` om te testen op aanwezigheid van sleutels in plaats van lijstindexen, passend bij de nieuwe data-indeling.
- Update van `README.md` om de aangepaste outputstructuur te tonen.

Voordelen:
- Verbeterde leesbaarheid en efficiëntie bij het ophalen van gegevens per verblijfsobject-ID.
- Vermindering van iteratienoden bij het werken met specifieke ID’s in de resultaten. 