### PR TITLE
Monumenten op meerdere percelen

### DIFF
--- a/src/monumenten/_api/_kadaster.py
+++ b/src/monumenten/_api/_kadaster.py
@@ -22,6 +22,8 @@ where {{
           geo:hasGeometry/geo:asWKT ?verblijfsobjectWKT;
           imx:isAdresVanGebouw ?gebouw.
   ?gebouw imx:bevindtZichOpPerceel ?perceel.
+  ?perceel geo:hasGeometry/geo:asWKT ?perceelWKT.
+  FILTER (geof:sfWithin(?verblijfsobjectWKT, ?perceelWKT))
 
   optional {{
     ?beperking <http://modellen.geostandaarden.nl/def/imx-geo#isBeperkingOpPerceel> ?perceel.

--- a/src/monumenten/client.py
+++ b/src/monumenten/client.py
@@ -106,7 +106,7 @@ class MonumentenClient:
             merged["grondslag_gemeentelijk_monument"].notna(),
         )
 
-        return merged.drop_duplicates(subset=["bag_verblijfsobject_id"])
+        return merged
 
     async def process_from_list(
         self, verblijfsobject_ids: List[str], to_vera: bool = False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ async def test_process_from_list(client):
         "0599010000281115",
         "0599010000076715",
         "0599010000146141",
+        "0232010000002251",  # gebouw ligt volgens kadaster op meerdere percelen
     ]
 
     result = await client.process_from_list(bag_verblijfsobject_ids)
@@ -55,6 +56,16 @@ async def test_process_from_list(client):
     assert result["0599010000076715"]["is_gemeentelijk_monument"] is True
     assert (
         result["0599010000076715"]["grondslag_gemeentelijk_monument"]
+        == "Gemeentewet: Aanwijzing gemeentelijk monument (voorbescherming, aanwijzing, afschrift)"
+    )
+
+    # Test gemeentelijk monument op meerdere percelen
+    assert "0232010000002251" in result
+    assert result["0232010000002251"]["is_rijksmonument"] is False
+    assert result["0232010000002251"]["is_beschermd_gezicht"] is False
+    assert result["0232010000002251"]["is_gemeentelijk_monument"] is True
+    assert (
+        result["0232010000002251"]["grondslag_gemeentelijk_monument"]
         == "Gemeentewet: Aanwijzing gemeentelijk monument (voorbescherming, aanwijzing, afschrift)"
     )
 


### PR DESCRIPTION
Wanneer een gebouw in het Kadaster aan meerdere percelen is gekoppeld gaf dit een fout. We filteren nu op percelen waar het punt van het verblijfsobject geometrisch binnen valt.

closes #14 